### PR TITLE
add back NO_AUTH_TENANT and NO_AUTH_URL env vars for tox

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 env:
-  - TOXENV=py27
+  - TOXENV=py27 AUTH_URL=http://staging.metrics.api.rackspacecloud.com AUTH_USER_NAME=cmetrixqe_cmsvcadmin AUTH_TENANT=836986 AUTH_API_KEY=01adb389e2fa422c93abfeb8996484f9
 install:
   - travis_retry pip install tox==1.6.1
 script:

--- a/tox.ini
+++ b/tox.ini
@@ -2,12 +2,11 @@
 envlist = py27,flake8
 
 [testenv]
-passenv=AUTH_API_KEY AUTH_USER_NAME AUTH_TENANT AUTH_URL
+passenv=AUTH_API_KEY AUTH_USER_NAME AUTH_TENANT AUTH_URL NO_AUTH_TENANT NO_AUTH_URL
 deps=-r{toxinidir}/test_requirements.txt
 commands=nosetests
 
 [testenv:flake8]
 basepython=python
-passenv=AUTH_API_KEY AUTH_USER_NAME AUTH_TENANT AUTH_URL
 deps=flake8
 commands=flake8 {toxinidir}/blueflood_graphite_finder {toxinidir}/tests


### PR DESCRIPTION
Add back env vars  NO_AUTH_TENANT and NO_AUTH_URL to tox.ini

and fix .travis.yml