### PR TITLE
add sum so counters are displayed properly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,5 @@ language: python
 install:
   - travis_retry pip install tox==1.6.1
 script:
-  - export AUTH_TENANT=$AUTH_TENANT
-  - export AUTH_URL=$AUTH_URL 
-  - export AUTH_API_KEY=$AUTH_API_KEY 
-  - export AUTH_USER_NAME=$AUTH_USER_NAME
   - export TOXENV=py27
   - travis_retry tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,10 @@
 language: python
-env:
-  - TOXENV=py27 AUTH_URL=http://staging.metrics.api.rackspacecloud.com AUTH_USER_NAME=cmetrixqe_cmsvcadmin AUTH_TENANT=836986 AUTH_API_KEY=01adb389e2fa422c93abfeb8996484f9
 install:
   - travis_retry pip install tox==1.6.1
 script:
+  - export AUTH_TENANT=$AUTH_TENANT
+  - export AUTH_URL=$AUTH_URL 
+  - export AUTH_API_KEY=$AUTH_API_KEY 
+  - export AUTH_USER_NAME=$AUTH_USER_NAME
+  - export TOXENV=py27
   - travis_retry tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,11 @@
 language: python
+env:
+  - AUTH_URL=$AUTH_URL
+  - AUTH_TENANT=$AUTH_TENANT
+  - AUTH_USER_NAME=$AUTH_USER_NAME
+  - AUTH_API_KEY=$AUTH_API_KEY
+  - TOXENV=py27
 install:
   - travis_retry pip install tox==1.6.1
 script:
-  - export TOXENV=py27
   - travis_retry tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,10 @@
 language: python
-env:
-  - AUTH_URL=$AUTH_URL
-  - AUTH_TENANT=$AUTH_TENANT
-  - AUTH_USER_NAME=$AUTH_USER_NAME
-  - AUTH_API_KEY=$AUTH_API_KEY
-  - TOXENV=py27
 install:
   - travis_retry pip install tox==1.6.1
 script:
+  - export AUTH_URL=$AUTH_URL
+  - export AUTH_TENANT=$AUTH_TENANT
+  - export AUTH_USER_NAME=$AUTH_USER_NAME
+  - export AUTH_API_KEY=$AUTH_API_KEY
+  - export TOXENV=py27
   - travis_retry tox

--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@ The BF finder is the graphite plugin that allows graphite and grafana to use blu
 
 In your graphite-api config file:
 
-
     finders:
       - blueflood_graphite_finder.blueflood.TenantBluefloodFinder
     blueflood:
@@ -72,5 +71,6 @@ To run nosetests, run the below commands
     
 ## Changelog
     
+* 1.0.2 (2017-05-31) Fix Grafana display issue for Counters
 * 1.0.1 (2016-03-25) Performance improvements for /metrics/find API.
 * 1.0.0 (2016-03-23) Base version. 

--- a/blueflood_graphite_finder/blueflood.py
+++ b/blueflood_graphite_finder/blueflood.py
@@ -396,7 +396,7 @@ class BluefloodClient(object):
         # Determines which key to use for the data
         if not len(values):
             return NonNestedDataKey(None)
-        value_res_order = ['average', 'latest', 'numPoints']
+        value_res_order = ['average', 'latest', 'sum', 'numPoints']
         present_keys = [v for v in value_res_order if v in values[0]]
         if present_keys:
             return NonNestedDataKey(present_keys[0])

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -127,6 +127,8 @@ class BluefloodTests(TestCase):
         auth.set_auth(None)
 
     def run_find(self, finder):
+        foo = finder.find_nodes(FindQuery('*', 0, 100))
+        print foo
         nodes = list(finder.find_nodes(FindQuery('*', 0, 100)))
         self.assertTrue(len(nodes) > 0)
 


### PR DESCRIPTION
When we view a counter, we get back this kind of data:
```
  "values": [
    {
      "numPoints": 75,
      "sum": 25,
      "timestamp": 1495851300000
    },
    ...
   ]
```

The 'numPoints' and 'sum' attributes used to show the same exact value. However, for this PR:
https://github.com/rackerlabs/blueflood/pull/591
the semantic of 'numPoints' was changed to return sample count.

For displaying Counters in Grafana, people are mostly going to be interested in graphing the sum, not sample count.

This PR fixes the finder so that it picks up sum first before numPoints. This should be fine for other types of StatsD metrics. According to this:
https://one.rackspace.com/pages/viewpage.action?title=Sub+Metrics+or+Stats&spaceKey=cloudmetrics#SubMetricsorStats-BluefloodSubMetricsSupport

there is only one other metric, Timer, for which Blueflood returns sum. And for Timer, the average is going to take precedence over sum.
