### PR TITLE
include license file in pypi distribution

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include LICENSE.txt


### PR DESCRIPTION
The Apache license [requires that a copy of the license be distributed with the software](https://github.com/rackerlabs/blueflood-graphite-finder/blob/08515ba5fbb534cf90df65c66437394c1b3e8129/LICENSE.txt#L89-L128).  The sdist tarball from PyPI does not currently include this.